### PR TITLE
Add PublishBatch feature

### DIFF
--- a/benchmarks/in-memory-string-concurrent/main.go
+++ b/benchmarks/in-memory-string-concurrent/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"log"
+	"runtime"
+	"sync/atomic"
+	"time"
+
+	"github.com/neutrinocorp/streamhub"
+	streamhub_memory "github.com/neutrinocorp/streamhub/streamhub-memory"
+)
+
+type transactionRegistered struct {
+	TxID   string  `json:"tx_id"`
+	Amount float64 `json:"amount"`
+}
+
+var totalProcessedMessages = uint64(0)
+var totalGoroutines = uint64(0)
+
+func main() {
+	baseCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	b := streamhub_memory.NewBus(1024)
+	hub := streamhub.NewHub(
+		streamhub.WithPublisher(streamhub_memory.NewPublisher(b)),
+		streamhub.WithListenerDriver(streamhub_memory.NewListener(b)))
+
+	registerStream(hub)
+	registerListeners(hub)
+
+	go func() {
+		hub.Start(baseCtx)
+	}()
+
+	timeFrame := time.NewTimer(time.Second * 1)
+	defer timeFrame.Stop()
+	publishMessages(timeFrame, hub)
+	time.Sleep(time.Second)
+	log.Printf("processed messages: %d msg/sec", totalProcessedMessages)
+	log.Printf("total goroutines used: %d", totalGoroutines)
+	//time.Sleep(time.Second * 3)
+	log.Printf("total goroutines at shutdown: %d", runtime.NumGoroutine())
+}
+
+func registerStream(h *streamhub.Hub) {
+	h.RegisterStreamByString("ncorp.wallet.tx.registered", streamhub.StreamMetadata{
+		Stream: "ncorp.wallet.tx.registered",
+		GoType: nil,
+	})
+}
+
+func registerListeners(h *streamhub.Hub) {
+	h.ListenByStreamKey("ncorp.wallet.tx.registered",
+		streamhub.WithConcurrencyLevel(2),
+		streamhub.WithListenerFunc(func(ctx context.Context, message streamhub.Message) error {
+			atomic.AddUint64(&totalProcessedMessages, 1)
+			atomic.StoreUint64(&totalGoroutines, uint64(runtime.NumGoroutine()))
+			return nil
+		}))
+}
+
+func publishMessages(timeFrame *time.Timer, h *streamhub.Hub) {
+	for {
+		go func() {
+			_ = h.PublishByMessageKey(context.Background(), "ncorp.wallet.tx.registered", transactionRegistered{
+				TxID:   "1",
+				Amount: 99.99,
+			})
+		}()
+		select {
+		case <-timeFrame.C:
+			return
+		default:
+		}
+	}
+}

--- a/common_test.go
+++ b/common_test.go
@@ -54,3 +54,24 @@ func (h hashing64AlgorithmFailingNoop) BlockSize() int {
 func (h hashing64AlgorithmFailingNoop) Sum64() uint64 {
 	return 0
 }
+
+type publisherNoopHook struct {
+	onPublish      func(context.Context, streamhub.Message) error
+	onPublishBatch func(context.Context, ...streamhub.Message) error
+}
+
+var _ streamhub.Publisher = publisherNoopHook{}
+
+func (p publisherNoopHook) Publish(ctx context.Context, message streamhub.Message) error {
+	if p.onPublish != nil {
+		return p.onPublish(ctx, message)
+	}
+	return nil
+}
+
+func (p publisherNoopHook) PublishBatch(ctx context.Context, messages ...streamhub.Message) error {
+	if p.onPublishBatch != nil {
+		return p.onPublishBatch(ctx, messages...)
+	}
+	return nil
+}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,6 @@
+package streamhub
+
+import "errors"
+
+// ErrMissingPublisherDriver no publisher driver was found
+var ErrMissingPublisherDriver = errors.New("streamhub: Missing publisher driver")

--- a/hub_options.go
+++ b/hub_options.go
@@ -3,7 +3,6 @@ package streamhub
 type hubOptions struct {
 	instanceName       string
 	publisher          Publisher
-	publisherFunc      PublisherFunc
 	marshaler          Marshaler
 	idFactory          IDFactoryFunc
 	schemaRegistry     SchemaRegistry
@@ -28,21 +27,6 @@ func (o instanceNameOption) apply(opts *hubOptions) {
 // WithInstanceName sets the name of a Hub instance.
 func WithInstanceName(n string) HubOption {
 	return instanceNameOption{Instance: n}
-}
-
-type publisherFuncOption struct {
-	PublisherFunc PublisherFunc
-}
-
-func (o publisherFuncOption) apply(opts *hubOptions) {
-	opts.publisherFunc = o.PublisherFunc
-}
-
-// WithPublisherFunc sets the publisher function of a Hub instance.
-//
-// If both Publisher and PublisherFunc are defined, Publisher will override PublisherFunc.
-func WithPublisherFunc(p PublisherFunc) HubOption {
-	return publisherFuncOption{PublisherFunc: p}
 }
 
 type publisherOption struct {

--- a/hub_options_test.go
+++ b/hub_options_test.go
@@ -16,18 +16,9 @@ func TestWithInstanceName(t *testing.T) {
 	assert.Equal(t, "org.neutrino", hub.InstanceName)
 }
 
-func TestWithPublisherFunc(t *testing.T) {
-	hub := streamhub.NewHub()
-	assert.IsType(t, streamhub.NoopPublisherFunc, hub.PublisherFunc)
-
-	hub = streamhub.NewHub(
-		streamhub.WithPublisherFunc(streamhub.NoopPublisherFunc))
-	assert.IsType(t, streamhub.NoopPublisherFunc, hub.PublisherFunc)
-}
-
 func TestWithPublisher(t *testing.T) {
 	hub := streamhub.NewHub()
-	assert.Nil(t, hub.Publisher)
+	assert.IsType(t, streamhub.NoopPublisher, hub.Publisher)
 
 	hub = streamhub.NewHub(
 		streamhub.WithPublisher(streamhub.NoopPublisher))

--- a/publisher.go
+++ b/publisher.go
@@ -4,24 +4,20 @@ import (
 	"context"
 )
 
-// PublisherFunc inserts a message into a stream assigned to the message in the StreamRegistry in order to propagate the
+// Publisher inserts messages into streams assigned on the StreamRegistry in order to propagate the
 // data to a set of subscribed systems for further processing.
-//
-// This type should be provided by a streamhub Driver (e.g. Apache Pulsar, Apache Kafka, Amazon SNS)
-type PublisherFunc func(ctx context.Context, message Message) error
-
-// Publisher is a wrapping structure of PublishMessageFunc for complex message publishing scenarios.
 //
 // This type should be provided by a streamhub Driver (e.g. Apache Pulsar, Apache Kafka, Amazon SNS)
 type Publisher interface {
 	// Publish inserts a message into a stream assigned to the message in the StreamRegistry in order to propagate the
 	// data to a set of subscribed systems for further processing.
 	Publish(ctx context.Context, message Message) error
-}
-
-// NoopPublisherFunc is the no-operation implementation of PublisherFunc
-var NoopPublisherFunc PublisherFunc = func(ctx context.Context, message Message) error {
-	return nil
+	// PublishBatch inserts a set of messages into a stream assigned to the message in the StreamRegistry in order to propagate the
+	// data to a set of subscribed systems for further processing.
+	//
+	// Depending on the underlying Publisher driver implementation, this function MIGHT return an error if a single operation failed,
+	// or it MIGHT return an error if the whole operation failed
+	PublishBatch(ctx context.Context, messages ...Message) error
 }
 
 type noopPublisher struct{}
@@ -31,5 +27,10 @@ var NoopPublisher Publisher = noopPublisher{}
 
 // Publish is the no-operation implementation of Publisher.Publish()
 func (n noopPublisher) Publish(_ context.Context, _ Message) error {
+	return nil
+}
+
+// PublishBatch is the no-op implementation of Publisher.PublishBatch()
+func (n noopPublisher) PublishBatch(_ context.Context, _ ...Message) error {
 	return nil
 }

--- a/stream_registry.go
+++ b/stream_registry.go
@@ -20,6 +20,11 @@ type StreamMetadata struct {
 // retrieve information about a specific stream.
 //
 // Uses a custom string (or Go's struct type as string) as key.
+//
+// Note: A message key differs from stream name as the message key COULD be anything the developer sets within the
+// stream registry. Thus, scenarios where multiple data types require publishing messages to the same stream are possible.
+// Moreover, the message key is set by reflection-based registries with the reflect.TypeOf function, so it will differ
+// from the actual stream name.
 type StreamRegistry map[string]StreamMetadata
 
 // Set creates a relation between a stream message type and metadata.

--- a/streamhub-memory/publisher.go
+++ b/streamhub-memory/publisher.go
@@ -26,3 +26,13 @@ func NewPublisher(b *Bus) *Publisher {
 func (p *Publisher) Publish(ctx context.Context, message streamhub.Message) error {
 	return p.b.publish(ctx, message)
 }
+
+// PublishBatch pushes the given set of messages into the internal in-memory Bus
+func (p *Publisher) PublishBatch(ctx context.Context, messages ...streamhub.Message) (err error) {
+	for _, msg := range messages {
+		if errPub := p.b.publish(ctx, msg); errPub != nil {
+			err = errPub
+		}
+	}
+	return
+}

--- a/streamhub-memory/publisher_test.go
+++ b/streamhub-memory/publisher_test.go
@@ -46,3 +46,41 @@ func TestPublisher_Publish(t *testing.T) {
 	// ensure goroutines were de-scheduled
 	assert.Equal(t, 2, runtime.NumGoroutine())
 }
+
+func TestPublisher_PublishBatch(t *testing.T) {
+	assert.Equal(t, 2, runtime.NumGoroutine())
+
+	bus := streamhub_memory.NewBus(0)
+	p := streamhub_memory.NewPublisher(bus)
+	err := p.PublishBatch(context.Background(), streamhub.Message{
+		Stream: "foo-stream",
+	})
+	assert.ErrorIs(t, err, streamhub_memory.ErrBusNotStarted)
+	assert.Equal(t, 2, runtime.NumGoroutine())
+
+	d := streamhub_memory.NewListener(bus)
+	baseCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
+	defer cancel()
+	err = d.ExecuteTask(baseCtx, streamhub.ListenerTask{
+		Stream: "foo-stream",
+		HandlerFunc: func(ctx context.Context, message streamhub.Message) error {
+			assert.Equal(t, "foo-stream", message.Stream)
+			return nil
+		},
+		Group:         "",
+		Configuration: nil,
+		Timeout:       0,
+	})
+	assert.NoError(t, err)
+	err = p.PublishBatch(context.Background(), streamhub.Message{
+		Stream: "foo-stream",
+	}, streamhub.Message{
+		Stream: "foo-stream",
+	})
+	assert.NoError(t, err)
+	// in-memory message bus adds two go routines, one for message buffer subscription and another for graceful shutdown
+	assert.LessOrEqual(t, 4, runtime.NumGoroutine())
+	time.Sleep(time.Millisecond * 200)
+	// ensure goroutines were de-scheduled
+	assert.Equal(t, 2, runtime.NumGoroutine())
+}


### PR DESCRIPTION
- Added `Hub.PublishBatch` functionality. Now a Hub has the ability to publish a set of messages to a stream in a most likely single network call.

Note: Each driver will require to deal with batch publishing. In addition, streamhub base package does not deal with it directly as every driver and/or transport protocol deals with batches differently from each other. 